### PR TITLE
Jsonify input, add output array

### DIFF
--- a/src/request-data.cpp
+++ b/src/request-data.cpp
@@ -113,7 +113,19 @@ struct request_data_handler_response request_data_handler(url_source_request_dat
 				}
 				request_data->last_obs_text_source_value = text;
 			}
-			json["input"] = text;
+			// if one of the headers is Content-Type application/json, make sure the text is JSONified
+			std::string textStr = text;
+			for (auto header : request_data->headers) {
+				if (header.first == "Content-Type" &&
+				    header.second == "application/json") {
+					nlohmann::json tmp = text;
+					textStr = tmp.dump();
+					// remove '"' from the beginning and end of the string
+					textStr = textStr.substr(1, textStr.size() - 2);
+					break;
+				}
+			}
+			json["input"] = textStr;
 		}
 
 		// Replace the {input} placeholder with the source text

--- a/src/url-source.cpp
+++ b/src/url-source.cpp
@@ -257,6 +257,8 @@ void curl_loop(struct url_source_data *usd)
 							data["output" + std::to_string(i)] =
 								response.body_parts_parsed[i];
 						}
+						// in "output" add an array of all the outputs
+						data["output"] = response.body_parts_parsed;
 					} else {
 						data["output"] = response.body_parts_parsed[0];
 					}


### PR DESCRIPTION
Adding `{{output}}` for array parses which holds the entire array

JSONifying `{{input}}` in case the content-type is application/json